### PR TITLE
Add trace logging for humidity sensor values from the API.

### DIFF
--- a/thermostat.groovy
+++ b/thermostat.groovy
@@ -396,6 +396,10 @@ log.debug "https://mytotalconnectcomfort.com/portal/Device/CheckDataSession/${se
         def statusHeat = response.data.latestData.uiData.StatusHeat
         
 
+	log.trace("IndoorHumidity: ${response.data.latestData.uiData.IndoorHumidity}")
+	log.trace("IndoorHumiditySensorAvailable: ${response.data.latestData.uiData.IndoorHumiditySensorAvailable}")        
+	log.trace("IndoorHumiditySensorNotFault: ${response.data.latestData.uiData.IndoorHumiditySensorNotFault}")        
+	log.trace("IndoorHumidStatus: ${response.data.latestData.uiData.IndoorHumidStatus}")        
 
         
         


### PR DESCRIPTION
Here's the pull request to get the trace information from (what I think are) the relevant values returned by the API.

If someone who has a thermostat that DOES NOT have a humidity sensor could run this version and report the four lines from their IDE logs, I'd appreciate it.
